### PR TITLE
Do not open Postgres port in docker-compose.yml.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ version: '3'
 services:
   postgres:
     image: postgres:12-alpine
-    ports:
-      - 5432:5432
     volumes:
       - .data/postgres:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
Expose the Postgres port could lead to potential security risks, I would recommend that remove that port. This won't affect the other containers defined in `docker-compose.yml` to access Postgres.