### PR TITLE
Update docker-compose.yml with startup healthcheck (v0.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Ian He & Jay Ji",
   "license": "MIT",
   "devDependencies": {
-    "@polkadot/api": "^6",
+    "@polkadot/api": "^7",
     "@subql/types": "latest",
     "typescript": "^4.1.3",
     "@subql/cli": "latest"


### PR DESCRIPTION
Adds a startup health check for docker compose so that images are only starting when they their dependents are healthy and ready (not just started)

Note that this depends on the **latest** dockerhub versions of `subql/node` but has been tested using a prerelease docker image of subql node to include `curl` which is needed for the health check. In order to merge this the following commit (https://github.com/subquery/subql/commit/07940fda11d5c4ce1a4c2b238da74a009bfc6507) **must have been put into a release and been published to the latest tag on dockerhub in order to merge this**

# Only merge when above has been satisfied