### PR TITLE
Update docker-compose.yml with startup healthcheck (v0.2.0)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 services:
   postgres:
@@ -9,11 +9,17 @@ services:
       - .data/postgres:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   subquery-node:
     image: onfinality/subql-node:latest
     depends_on:
-      - "postgres"
+      "postgres":
+        condition: service_healthy
     restart: always
     environment:
       DB_USER: postgres
@@ -26,14 +32,21 @@ services:
     command:
       - -f=/app
       - --db-schema=app
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://subquery-node:3000/ready"]
+      interval: 3s
+      timeout: 5s
+      retries: 10
 
   graphql-engine:
     image: onfinality/subql-query:latest
     ports:
       - 3000:3000
     depends_on:
-      - "postgres"
-      - "subquery-node"
+      "postgres":
+        condition: service_healthy
+      "subquery-node":
+        condition: service_healthy
     restart: always
     environment:
       DB_USER: postgres


### PR DESCRIPTION
Adds a startup health check for docker compose so that images are only starting when they their dependents are healthy and ready (not just started)

Note that this depends on the **latest** dockerhub versions of `subql/node` but has been tested using a prerelease docker image of subql node. **In order to merge this the following commit (https://github.com/subquery/subql/commit/d2be35621bbe4ae7b1ac1e2623dfeb9e9d570845) must have been put into a release and been published to the latest tag on dockerhub**