### PR TITLE
Downgrade polkadot version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2020-2021 OnFinality Limited authors & contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+MIT LICENSE
+
 Copyright 2020-2021 OnFinality Limited authors & contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - ./:/app
     command:
       - -f=/app
-      - --local
+      - --subquery-name=app
 
   graphql-engine:
     image: onfinality/subql-query:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - ./:/app
     command:
       - -f=/app
-      - --subquery-name=app
+      - --db-schema=app
 
   graphql-engine:
     image: onfinality/subql-query:latest

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Ian He & Jay Ji",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@polkadot/api": "^5.7.1",
+    "@polkadot/api": "^6",
     "@subql/types": "latest",
     "typescript": "^4.1.3",
     "@subql/cli": "latest"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "project.yaml"
   ],
   "author": "Ian He & Jay Ji",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "devDependencies": {
     "@polkadot/api": "^6",
     "@subql/types": "latest",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Ian He & Jay Ji",
   "license": "MIT",
   "devDependencies": {
-    "@polkadot/api": "^7",
+    "@polkadot/api": "^6",
     "@subql/types": "latest",
     "typescript": "^4.1.3",
     "@subql/cli": "latest"

--- a/project.yaml
+++ b/project.yaml
@@ -1,4 +1,4 @@
-specVersion: "0.0.2"
+specVersion: "0.2.0"
 
 name: "Subql-Starter"
 version: "0.0.0"

--- a/project.yaml
+++ b/project.yaml
@@ -9,11 +9,12 @@ schema:
   file: "./schema.graphql"
 
 network:
+  endpoint: 'wss://polkadot.api.onfinality.io/public-ws'
   genesisHash: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3' # Polkadot
 
 dataSources:
   - kind: substrate/Runtime
-    startBlock: 1
+    startBlock: 8197766
     mapping:
       file: "./dist/index.js"
       handlers:

--- a/project.yaml
+++ b/project.yaml
@@ -12,8 +12,7 @@ network:
   genesisHash: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3' # Polkadot
 
 dataSources:
-  - name: main
-    kind: substrate/Runtime
+  - kind: substrate/Runtime
     startBlock: 1
     mapping:
       file: "./dist/index.js"

--- a/project.yaml
+++ b/project.yaml
@@ -1,19 +1,22 @@
-specVersion: "0.0.1"
+specVersion: "0.0.2"
+
+name: "Subql-Starter"
+version: "0.0.0"
 description: ""
 repository: "https://github.com/subquery/subql-starter"
 
-schema: "./schema.graphql"
+schema:
+  file: "./schema.graphql"
 
 network:
-  endpoint: "wss://polkadot.api.onfinality.io/public-ws"
-  # Optionally provide the HTTP endpoint of a full chain dictionary to speed up processing
-  dictionary: "https://api.subquery.network/sq/subquery/dictionary-polkadot"
+  genesisHash: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3' # Polkadot
 
 dataSources:
   - name: main
     kind: substrate/Runtime
     startBlock: 1
     mapping:
+      file: "./dist/index.js"
       handlers:
         - handler: handleBlock
           kind: substrate/BlockHandler
@@ -24,7 +27,4 @@ dataSources:
             method: Deposit
         - handler: handleCall
           kind: substrate/CallHandler
-
-
-
 


### PR DESCRIPTION
Hi team,

A lot of people reporting build issues cause by the polkadot dep uprade e.g.:

```
node_modules/@polkadot/api-derive/balances/types.d.ts:3:15 - error TS2305: Module '"@polkadot/types/lookup"' has no
 exported member 'PalletBalancesBalanceLock'.
3 import type { PalletBalancesBalanceLock } from '@polkadot/types/lookup';
````

please check the #technical-support discord chat for more detail.

The issue can be fixed by downgrading the dep version to 6 (I guess the proper fix should in the code), but I think this downgrade should at least unblock new people who try to follow your subquery course

thanks