### PR TITLE
Downgrade polkadot/api version to 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Ian He & Jay Ji",
   "license": "MIT",
   "devDependencies": {
-    "@polkadot/api": "^7",
+    "@polkadot/api": "^6",
     "@subql/types": "latest",
     "typescript": "^4.1.3",
     "@subql/cli": "latest"


### PR DESCRIPTION
Hi team,

A lot of people are reporting build issues caused by the polkadot dep upgrade e.g.:

```
node_modules/@polkadot/api-derive/balances/types.d.ts:3:15 - error TS2305: Module '"@polkadot/types/lookup"' has no
 exported member 'PalletBalancesBalanceLock'.
3 import type { PalletBalancesBalanceLock } from '@polkadot/types/lookup';
````

please check the #technical-support discord chat for more detail.

The issue can be fixed by downgrading the dep version to 6 (I guess the proper fix should in the code), but I think this downgrade should at least unblock new people who try to follow your subquery course

thanks