### PR TITLE
@polkadot/api patch (v0.2.0)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 //Exports all handler functions
 export * from './mappings/mappingHandlers'
+import "@polkadot/api-augment"

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -1,4 +1,3 @@
-import "@polkadot/api-augment"
 import {SubstrateExtrinsic,SubstrateEvent,SubstrateBlock} from "@subql/types";
 import {StarterEntity} from "../types";
 import {Balance} from "@polkadot/types/interfaces";

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -1,3 +1,4 @@
+import "@polkadot/api-augment"
 import {SubstrateExtrinsic,SubstrateEvent,SubstrateBlock} from "@subql/types";
 import {StarterEntity} from "../types";
 import {Balance} from "@polkadot/types/interfaces";


### PR DESCRIPTION
Starter is broken due to breaking change in `@polkadot/api` version `7` that we did not check before upgrading. This fixes build issues