### PR TITLE
convert line endings to LF in load_extensions.sh

### DIFF
--- a/Acala/acala-evm-starter/docker/pg-Dockerfile
+++ b/Acala/acala-evm-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Acala/acala-starter/docker/pg-Dockerfile
+++ b/Acala/acala-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Ajuna/ajuna-starter/docker/pg-Dockerfile
+++ b/Ajuna/ajuna-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Altair/altair-starter/docker/pg-Dockerfile
+++ b/Altair/altair-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Astar/astar-evm-starter/docker/pg-Dockerfile
+++ b/Astar/astar-evm-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Astar/astar-starter/docker/pg-Dockerfile
+++ b/Astar/astar-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Astar/astar-wasm-starter/docker/pg-Dockerfile
+++ b/Astar/astar-wasm-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Automata/automata-starter/docker/pg-Dockerfile
+++ b/Automata/automata-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Basilisk/basilisk-starter/docker/pg-Dockerfile
+++ b/Basilisk/basilisk-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Bifrost/bifrost-starter/docker/pg-Dockerfile
+++ b/Bifrost/bifrost-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Bitcountry/bitcountry-starter/docker/pg-Dockerfile
+++ b/Bitcountry/bitcountry-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Bitgreen/bitgreen-starter/docker/pg-Dockerfile
+++ b/Bitgreen/bitgreen-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Calamari/calamari-starter/docker/pg-Dockerfile
+++ b/Calamari/calamari-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Centrifuge/centrifuge-starter/docker/pg-Dockerfile
+++ b/Centrifuge/centrifuge-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Clover/clover-starter/docker/pg-Dockerfile
+++ b/Clover/clover-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/ComposableFinance/composable-finance-starter/docker/pg-Dockerfile
+++ b/ComposableFinance/composable-finance-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Contextfree/contextfree-starter/docker/pg-Dockerfile
+++ b/Contextfree/contextfree-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Darwinia/darwinia-starter/docker/pg-Dockerfile
+++ b/Darwinia/darwinia-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Efinity/efinity-starter/docker/pg-Dockerfile
+++ b/Efinity/efinity-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Encointer/Encointer-starter/docker/pg-Dockerfile
+++ b/Encointer/Encointer-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Equilibrium/equilibrium-starter/docker/pg-Dockerfile
+++ b/Equilibrium/equilibrium-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Frequency/frequency-starter/docker/pg-Dockerfile
+++ b/Frequency/frequency-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/HashedNetwork/hashed-network-starter/docker/pg-Dockerfile
+++ b/HashedNetwork/hashed-network-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Humanode/Humanode-starter/docker/pg-Dockerfile
+++ b/Humanode/Humanode-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/HydraDX/hydradx-starter/docker/pg-Dockerfile
+++ b/HydraDX/hydradx-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/IntegriteeShell/integritee-shell-starter/docker/pg-Dockerfile
+++ b/IntegriteeShell/integritee-shell-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Interlay/interlay-starter/docker/pg-Dockerfile
+++ b/Interlay/interlay-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Kapex/kapex-starter/docker/pg-Dockerfile
+++ b/Kapex/kapex-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Karura/karura-evm-starter/docker/pg-Dockerfile
+++ b/Karura/karura-evm-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Karura/karura-starter/docker/pg-Dockerfile
+++ b/Karura/karura-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Khala/khala-starter/docker/pg-Dockerfile
+++ b/Khala/khala-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Kilt/kilt-spiritnet-credentials-example/docker/pg-Dockerfile
+++ b/Kilt/kilt-spiritnet-credentials-example/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Kilt/kilt-spiritnet-starter/docker/pg-Dockerfile
+++ b/Kilt/kilt-spiritnet-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Kusama/kusama-starter/docker/pg-Dockerfile
+++ b/Kusama/kusama-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Kylin/kylin-starter/docker/pg-Dockerfile
+++ b/Kylin/kylin-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Moonbeam/Moonbeam-starter/docker/pg-Dockerfile
+++ b/Moonbeam/Moonbeam-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Moonbeam/moonbeam-evm-starter/docker/pg-Dockerfile
+++ b/Moonbeam/moonbeam-evm-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Moonriver/Moonriver-starter/docker/pg-Dockerfile
+++ b/Moonriver/Moonriver-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Moonriver/moonriver-evm-starter/docker/pg-Dockerfile
+++ b/Moonriver/moonriver-evm-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Nodle/nodle-starter/docker/pg-Dockerfile
+++ b/Nodle/nodle-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/OriginTrail/origintrail-starter/docker/pg-Dockerfile
+++ b/OriginTrail/origintrail-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Parallel/parallel-heiko-starter/docker/pg-Dockerfile
+++ b/Parallel/parallel-heiko-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Parallel/parallel-starter/docker/pg-Dockerfile
+++ b/Parallel/parallel-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Polkadex/polkadex-starter/docker/pg-Dockerfile
+++ b/Polkadex/polkadex-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Polkadot/Polkadot-starter/docker/pg-Dockerfile
+++ b/Polkadot/Polkadot-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Quartz/quartz-subql-starter/docker/pg-Dockerfile
+++ b/Quartz/quartz-subql-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Shiden/shiden-starter/docker/pg-Dockerfile
+++ b/Shiden/shiden-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Statemine/statemine-starter/docker/pg-Dockerfile
+++ b/Statemine/statemine-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Statemint/statemint-starter/docker/pg-Dockerfile
+++ b/Statemint/statemint-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Unique/unique-starter/docker/pg-Dockerfile
+++ b/Unique/unique-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Vara/vara-starter/docker/pg-Dockerfile
+++ b/Vara/vara-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Watr/watr-starter/docker/pg-Dockerfile
+++ b/Watr/watr-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh

--- a/Westend/westend-starter/docker/pg-Dockerfile
+++ b/Westend/westend-starter/docker/pg-Dockerfile
@@ -7,3 +7,6 @@ ENV POSTGRES_PASSWORD 'postgres'
 
 # Copy in the load-extensions script
 COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/
+
+# Convert line endings to LF
+RUN sed -i 's/\r$//' /docker-entrypoint-initdb.d/load-extensions.sh && chmod +x /docker-entrypoint-initdb.d/load-extensions.sh


### PR DESCRIPTION
Running docker on a windows system will throw this error:

```
/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/load-extensions.sh
/usr/local/bin/docker-entrypoint.sh: /docker-entrypoint-initdb.d/load-extensions.sh: /bin/sh^M: bad interpreter: No such file or directory
```

The error message suggests that the load-extensions.sh script has Windows-style line endings (CRLF). Unix-like systems (like the one inside our Docker container) expect Linux-style line endings (LF), and the ^M character is a representation of the extra CR character that Windows uses.

To resolve this issue, we need to convert the line endings in our load-extensions.sh script from Windows-style (CRLF) to Unix-style (LF).