### PR TITLE
Fix polkadot starter

### DIFF
--- a/Polkadot/Polkadot-starter/src/mappings/mappingHandlers.ts
+++ b/Polkadot/Polkadot-starter/src/mappings/mappingHandlers.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import {
   SubstrateExtrinsic,
   SubstrateEvent,
@@ -25,9 +26,12 @@ export async function handleEvent(event: SubstrateEvent): Promise<void> {
   // logger.info(JSON.stringify(event));
   const {
     event: {
-      data: [from, to, amount],
+      data: [to, amount],
     },
   } = event;
+
+  const from = event.extrinsic?.extrinsic.signer;
+  assert(from, "Signer is missing");
 
   const blockNumber: number = event.block.block.header.number.toNumber();
 


### PR DESCRIPTION
https://github.com/subquery/subql-starter/pull/88 applied an updated starter to all networks but the events can be different.

I've only fixed polkadot because thats a project used for testing. Im unsure if other networks have the same issues